### PR TITLE
Some typo and hyperlink corrections

### DIFF
--- a/public/coneref/refblock.html
+++ b/public/coneref/refblock.html
@@ -31,6 +31,8 @@
 			finishes at the end of a line, as is typically the case.
 			This example show two expression statements:</p>
 <pre>
+mut a i32
+imm b i32
 a = 12   // Equivalent to: a = 12;
 b = 5    // Equivalent to: b = 5;
 </pre>
@@ -191,15 +193,15 @@ a = {
 <pre>
 // Calculate the value of 'this' (0.174533)
 with Float.Pi/180:
-	quarter = 90 * this  // Use 'this' to convert to radians
-	acute = 10 * this
+	quarter = 90f * this // Use 'this' to convert to radians
+	acute = 10f * this
 </pre>
 	<p>The above example is short-hand for:</p>
 <pre>
 {
 	imm this = Float.Pi/180
-	quarter = 90 * this  // Use 'this' to convert to radians
-	acute = 10 * this	
+	quarter = 90f * this // Use 'this' to convert to radians
+	acute = 10f * this
 }
 </pre>
 	<p>Since <span class="pre">with</span> blocks can be nested within each other,
@@ -218,7 +220,7 @@ with Float.Pi/180:
 		taking advantage of this shortcut:</p>
 <pre>
 // Normalize point to unit length
-with point:
+with &mut point:
 	imm len = (.x * .x + .y * .y).sqrt
 	if len > 0:
 		.x /= len

--- a/public/coneref/refblock.html
+++ b/public/coneref/refblock.html
@@ -13,6 +13,10 @@
 
     <div class="text">
 
+		<p style="margin-left: 40px;"><i>Note: All of this capability is implemented
+				except for '.[]' indexing and the '<-' Prefix Operator.</i>
+		</p>
+
 		<p>A block is the basic unit for structured control flow.
 			It holds a ordered collection of statements that are executed in order, starting with the first statement.
 			It may also accumulate its own temporary, local state.

--- a/public/coneref/refcloref.html
+++ b/public/coneref/refcloref.html
@@ -44,7 +44,7 @@ handler()
 </pre>
 
 	<p style="text-align: right; margin-top: 2em;">
-		<a href="reftypecoll.html"><img alt="_" src="next.png" /></a>
+		<a href="reftypemanage.html"><img alt="_" src="next.png" /></a>
 	</p>
 
 	</div>

--- a/public/coneref/refexpr.html
+++ b/public/coneref/refexpr.html
@@ -68,7 +68,9 @@
 <pre>
 // The method name equivalent for the + operator is `+`
 // The method name is enclosed in backticks since it includes punctuation
-3+4   // is actually: 3.`+`(4)
+3+4 // is actually the same as: 3 .`+`(4)
+// The space between 3 and . is needed here, otherwise 3. would be parsed as the float 3.0
+// When using a variable this space is not needed: n.`+`(4)
 </pre>
 	</li>
 	</ul>

--- a/public/coneref/refinclude.html
+++ b/public/coneref/refinclude.html
@@ -187,7 +187,7 @@ extern:
 	via a simple <span class="pre">include</span>.</p>
 
 	<p style="text-align: right; margin-top: 2em;">
-		<a href="reftypecomp.html"><img alt="_" src="next.png" /></a>
+		<a href="refmeta.html"><img alt="_" src="next.png" /></a>
 	</p>
 
 	</div>

--- a/public/coneref/refmeta.html
+++ b/public/coneref/refmeta.html
@@ -64,7 +64,7 @@ imm #arrsize = 10
 		
 				
 	<p style="text-align: right; margin-top: 2em;">
-		<a href="refmacro.html"><img alt="_" src="next.png" /></a>
+		<a href="refsafety.html"><img alt="_" src="next.png" /></a>
 	</p>
 
 	</div>

--- a/public/coneref/refptr.html
+++ b/public/coneref/refptr.html
@@ -96,7 +96,7 @@ trust{ptr1[2] = ptr2[1]}
 
 	
 	<p style="text-align: right; margin-top: 2em;">
-		<a href="refgeneric.html"><img alt="_" src="next.png" /></a>
+		<a href="reftoken.html"><img alt="_" src="next.png" /></a>
 	</p>
 
 	</div>


### PR DESCRIPTION
refexpr:  print <- 3 .`+`(4)  // => 7  (3 space .)      

refblock imm or mut before a, b

		 with Float.Pi/180:
		quarter = 90f * this  // Use 'this' to convert to radians
		acute = 10f * this
			<- otherwise: Error 1042: No matching method '*' found that matches the call's arguments.


		with point:  --> with &mut point

	
Hyperlink errors:
-----------------
1) from refcloref.html  --> reftypecoll.html
	should be: reftypemanage.html
2) from refmeta.html --> refmacro
	should be: refsafety

3)  rawpointers -->  refgeneric
	should be: reftoken

4) refinclude.html --> reftypecomp 
	<-- does not appear in TOC
	should be: refmeta

